### PR TITLE
rebase "zumapro-sepolicy: Add missing qorvo UWB context" PR

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -1,5 +1,6 @@
 # Binaries
 /vendor/bin/hw/android\.hardware\.qorvo\.uwb\.service                       u:object_r:hal_uwb_vendor_default_exec:s0
+/vendor/bin/hw/android\.hardware\.qorvo\.uwb-service                        u:object_r:hal_uwb_default_exec:s0
 /vendor/bin/init_uwb_calib                                                  u:object_r:vendor_uwb_init_exec:s0
 /vendor/bin/dump/dump_power                                                 u:object_r:dump_power_exec:s0
 /vendor/bin/hw/android\.hardware\.usb-service                               u:object_r:hal_usb_impl_exec:s0


### PR DESCRIPTION
See https://github.com/GrapheneOS/device_google_zumapro-sepolicy/pull/4